### PR TITLE
add help text at the bottom

### DIFF
--- a/build/correlation-graph.js
+++ b/build/correlation-graph.js
@@ -58,6 +58,15 @@ function dragended(simulation) {
   d3.event.subject.fy = null;
 }
 
+function drawHelpText(props) {
+  var selector = props.selector;
+  var height = props.height;
+  var xOffset = 75;
+  var yOffset = height - 10;
+  var helpText = 'mouse over a node to see it\'s relationships. click the background to reset.';
+  d3.select(selector).append('g').attr('transform', 'translate(' + xOffset + ',' + yOffset + ')').append('text').style('fill', '#666').style('fill-opacity', 1).style('pointer-events', 'none').style('stroke', 'none').style('font-size', 10).text(helpText);
+}
+
 /* global d3 _ jLouvain window document */
 /* eslint-disable newline-per-chained-call */
 
@@ -326,6 +335,12 @@ function render(props) {
   var boundDragended = dragended.bind(this, simulation);
 
   node.call(d3.drag().on('start', boundDragstarted).on('drag', dragged).on('end', boundDragended));
+
+  // draw the help text
+  drawHelpText({
+    selector: 'svg',
+    height: height
+  });
 
   //
   // implement custom forces for clustering communities

--- a/src/drawHelpText.js
+++ b/src/drawHelpText.js
@@ -1,0 +1,16 @@
+export default function drawHelpText(props) {
+  const selector = props.selector;
+  const height = props.height;
+  const xOffset = 75;
+  const yOffset = height - 10;
+  const helpText = `mouse over a node to see it's relationships. click the background to reset.`;
+  d3.select(selector).append('g')
+    .attr('transform', `translate(${xOffset},${yOffset})`)
+    .append('text')
+    .style('fill', '#666')
+    .style('fill-opacity', 1)
+    .style('pointer-events', 'none')
+    .style('stroke', 'none')
+    .style('font-size', 10)
+    .text(helpText);
+}

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,7 @@ import ticked from './ticked';
 import dragstarted from './dragstarted';
 import dragged from './dragged';
 import dragended from './dragended';
+import drawHelpText from './drawHelpText';
 
 export default function render(props) {
   //
@@ -276,6 +277,7 @@ export default function render(props) {
   // draw labels
   const label = node.append('text')
     .text(d => d.name)
+
     .style('font-size', function (d) {
       if (typeof fixedNodeSize !== 'undefined') {
         return `${defaultRadius * 1}px`;
@@ -353,6 +355,12 @@ export default function render(props) {
       .on('drag', dragged)
       .on('end', boundDragended)
     );
+
+  // draw the help text
+  drawHelpText({
+    selector: 'svg',
+    height
+  });
 
   //
   // implement custom forces for clustering communities


### PR DESCRIPTION
This PR adds the help text `mouse over a node to see it's relationships. click the background to reset.` to the graphic

fix #28 

![screen shot 2017-03-29 at 5 19 30 pm](https://cloud.githubusercontent.com/assets/2119400/24482136/f002ab0c-14a3-11e7-9db2-46631cf0b34b.png)
